### PR TITLE
Expand singletons bound down to 2.7

### DIFF
--- a/clash-utils.cabal
+++ b/clash-utils.cabal
@@ -98,7 +98,7 @@ library
     build-depends:       
         base          >=4.8 && <5, 
         clash-prelude >=1.6 && <1.7, 
-        singletons    >=3   && <4,
+        singletons    >=2.7 && <4,
         ghc-typelits-natnormalise,
         ghc-typelits-knownnat,
         cereal        >=0.5 && <0.6,


### PR DESCRIPTION
Not sure if this is worth it, but project compiles just fine with 2.7 of singletons.  This was helpful to me, because it lets me use Stack LTS-18 and clash-wavdrom (with a single override of clash-prelude to 1.6.3).

Didn't seem to be any harm in this change, so I figured I'd try to upstream it!