### PR TITLE
Fix invalid haddock documentation.

### DIFF
--- a/src/Clash/Stream/Chain.hs
+++ b/src/Clash/Stream/Chain.hs
@@ -21,9 +21,9 @@ type VecStream a b dom m
     =  Signal dom Bool               -- ^ Downstream ready
     -> Vec m (Signal dom a)          -- ^ Incoming streams
     -> (
-            Vec m (Signal dom Bool), -- ^ Upstream readys
-            Signal dom b             -- ^ Outgoing streams
-    )
+            Vec m (Signal dom Bool),
+            Signal dom b
+       )                             -- ^ (Upstream readys, Outgoing streams)
 
 -- | Convenience function for merging streams together, correctly connecting up their ready signals
 chainStreamVec

--- a/src/Clash/Stream/Mux.hs
+++ b/src/Clash/Stream/Mux.hs
@@ -15,9 +15,9 @@ streamMux
     => Signal dom Bool                    -- ^ Downstream ready
     -> Vec m (Signal dom (Bool, Bool, a)) -- ^ Incoming streams
     -> (
-            Vec m (Signal dom Bool),      -- ^ Upstream readys
-            Signal dom (Bool, Bool, a)    -- ^ Outgoing streams
-    )
+            Vec m (Signal dom Bool),
+            Signal dom (Bool, Bool, a)
+       )                                  -- ^ (Upstream readys, Outgoing streams)
 streamMux ready streams = (readys, activeStream)
     where
 
@@ -45,9 +45,9 @@ streamMuxLowLatency
     => Signal dom Bool                    -- ^ Downstream ready
     -> Vec m (Signal dom (Bool, Bool, a)) -- ^ Incoming streams
     -> (
-            Vec m (Signal dom Bool),      -- ^ Upstream readys
-            Signal dom (Bool, Bool, a)    -- ^ Outgoing streams
-    )
+            Vec m (Signal dom Bool),
+            Signal dom (Bool, Bool, a)
+       )                                  -- ^ (Upstream readys, Outgoing streams)
 streamMuxLowLatency ready streams = (readys, activeStream)
     where
 
@@ -81,9 +81,9 @@ streamMuxBiased
     => Signal dom Bool                    -- ^ Downstream ready
     -> Vec m (Signal dom (Bool, Bool, a)) -- ^ Incoming streams
     -> (
-            Vec m (Signal dom Bool),      -- ^ Upstream readys
-            Signal dom (Bool, Bool, a)    -- ^ Outgoing streams
-    )
+            Vec m (Signal dom Bool),
+            Signal dom (Bool, Bool, a)
+       )                                  -- ^ (Upstream readys, Outgoing streams)
 streamMuxBiased ready streams = (readys, activeStream)
     where
     readys :: Vec m (Signal dom Bool)


### PR DESCRIPTION
It's currently not possible to annotate the individual parts of tuples as function arguments.  This causes either a warning in later GHC versions, or crashes GHC in older ones.