### PR TITLE
Bound hashable

### DIFF
--- a/clash-utils.cabal
+++ b/clash-utils.cabal
@@ -171,7 +171,8 @@ Test-Suite test
         cereal                     >=0.5 && <0.6,
         hspec                      >=2.4 && < 3,
         hspec-discover             >=2.4 && < 3,
-        hashable                   >=1.2,
+        -- Hashable 1.4.3.0 introduces a change that breaks tests
+        hashable                   >=1.2 && < 1.4.3.0,
         data-default,
         tuple,
         bytestring,


### PR DESCRIPTION
The most recent release introduces a change that breaks Cuckoo tests.  Ideally tests would be updated, but this at least seemed like a good start.